### PR TITLE
Address configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ __pycache__
 *.log
 *.pyc
 SECRETS
+.permissions

--- a/Makefile
+++ b/Makefile
@@ -21,11 +21,17 @@
 ## OR SET ME IN THE ENV ##
 ##########################
 # - Choose "kme1" or "kme2" for the local KME identity.
+#   kme1 => local, kme2 => remote
 export KME ?= kme1
 # - Location of Local KME's guardian git repository
-export LOCAL_KME_DIRPATH ?= alice@kme1:/home/alice/code/guardian
+export LOCAL_KME_ADDRESS ?= s15qkd-f.internal
+export LOCAL_KME_DIRPATH ?= kme1@$(LOCAL_KME_ADDRESS):/home/kme1/code/guardian
 # - Location of Remote KME's guardian git repository
-export REMOTE_KME_DIRPATH ?= bob@kme2:/home/bob/code/guardian
+#   TODO: Verify currently only used to transfer keys (to be handled by qcrypto) and
+#         transfer certs (to replace full-chain authentication with int+root ca-chain)
+export REMOTE_KME_ADDRESS ?= s15qkd-g.internal
+export REMOTE_KME_DIRPATH ?= kme2@$(REMOTE_KME_ADDRESS):/home/kme2/code/guardian
+
 # NOTE:
 # - Set to <username>@<hostnameORip>:<path/to/guardian/repository>
 # - It is expected that passwordless SSH access is set up to this location.

--- a/common/global_config.py
+++ b/common/global_config.py
@@ -30,6 +30,8 @@ class GlobalSettings(BaseSettings):
     REMOTE_KME_ID: str = os.environ.get("REMOTE_KME_ID", "kme2")
     LOCAL_SAE_ID: str = os.environ.get("LOCAL_SAE_ID", "sae1")
     REMOTE_SAE_ID: str = os.environ.get("REMOTE_SAE_ID", "sae2")
+    LOCAL_KME_ADDRESS: str = os.environ.get("LOCAL_KME_ADDRESS", "kme1")
+    REMOTE_KME_ADDRESS: str = os.environ.get("REMOTE_KME_ADDRESS", "kme2")
     SHOW_SECRETS: bool = True
     VAULT_NAME: str = "vault"
     VAULT_SERVER_URL: str = f"https://{VAULT_NAME}:8200"

--- a/common/vault_init_config.py
+++ b/common/vault_init_config.py
@@ -36,11 +36,8 @@ class VaultInitSettings(BaseSettings):
     CLIENT_KEY_FILEPATH: str = f"{GLOBAL.CERT_DIRPATH}/{GLOBAL.VAULT_INIT_NAME}/{GLOBAL.VAULT_INIT_NAME}{GLOBAL.KEY_SUFFIX}"
     SECRET_SHARES: int = 5
     SECRET_THRESHOLD: int = 3
-    CLIENT_ALT_NAMES: str = f"{GLOBAL.LOCAL_SAE_ID}," \
-                            f"{GLOBAL.LOCAL_KME_ID}," \
-                            f"traefik.{GLOBAL.LOCAL_KME_ID}," \
-                            "localhost"
-    CLIENT_IP_SANS: str = "165.22.101.77,165.22.109.117"
+    CLIENT_ALT_NAMES: str = f"*.{GLOBAL.LOCAL_KME_ADDRESS},{GLOBAL.LOCAL_KME_ADDRESS}"
+    CLIENT_IP_SANS: str = "" # comma-delimited
 
     # Make environment settings take precedence over __init__ and file
     class Config:

--- a/docker-compose.init.yml
+++ b/docker-compose.init.yml
@@ -91,6 +91,7 @@ services:
       - REMOTE_KME_ID=${REMOTE_KME_ID:-SETMEINMAKEFILE}
       - LOCAL_SAE_ID=${LOCAL_SAE_ID:-SETMEINMAKEFILE}
       - REMOTE_SAE_ID=${REMOTE_SAE_ID:-SETMEINMAKEFILE}
+      - LOCAL_KME_ADDRESS=${LOCAL_KME_ADDRESS:-SETMEINMAKEFILE}
     env_file:
       - common/log.env
     command: ["vault_init.py", "--first"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,7 +62,7 @@ services:
       # "restapp-http" router redirects to websecure endpoint to force HTTPS
       - traefik.http.routers.restapp-http.entrypoints=web
       # Make Traefik use the LOCAL_KME_ID domain in for HTTP entrypoint or a Path prefix if that does not match
-      - traefik.http.routers.restapp-http.rule=Host(`${LOCAL_KME_ID:-SETMEINMAKEFILE}`)||PathPrefix(`/api/v1`)
+      - traefik.http.routers.restapp-http.rule=Host(`${LOCAL_KME_ADDRESS:-SETMEINMAKEFILE}`)||PathPrefix(`/api/v1`)
       # Use the traefik-public network (declared below)
       - traefik.docker.network=traefik-public
       # Turn on TLS for our "restapp-https" router
@@ -70,7 +70,7 @@ services:
       # websecure entrypoint defined in the Traefik configuration file
       - traefik.http.routers.restapp-https.entrypoints=websecure
       # Make Traefik use the LOCAL_KME_ID domain in for HTTPS entrypoint or a Path prefix if that does not match
-      - traefik.http.routers.restapp-https.rule=Host(`${LOCAL_KME_ID:-SETMEINMAKEFILE}`)||PathPrefix(`/api/v1`)
+      - traefik.http.routers.restapp-https.rule=Host(`${LOCAL_KME_ADDRESS:-SETMEINMAKEFILE}`)||PathPrefix(`/api/v1`)
       # Define middleware "client-cert-info" to pass more header info to app
       # Pass the SAE client's Common Name and SANs to rest app for parsing
       - traefik.http.middlewares.client-cert-info.passtlsclientcert.info.subject.commonname=true
@@ -153,6 +153,7 @@ services:
       - REMOTE_KME_ID=${REMOTE_KME_ID:-SETMEINMAKEFILE}
       - LOCAL_SAE_ID=${LOCAL_SAE_ID:-SETMEINMAKEFILE}
       - REMOTE_SAE_ID=${REMOTE_SAE_ID:-SETMEINMAKEFILE}
+      - LOCAL_KME_ADDRESS=${LOCAL_KME_ADDRESS:-SETMEINMAKEFILE}
     ports:
       # Listen on port 80, default for HTTP, necessary to redirect to HTTPS
       - 80:80

--- a/volumes/kme1/traefik/configuration/traefik.d/tls.yml
+++ b/volumes/kme1/traefik/configuration/traefik.d/tls.yml
@@ -2,12 +2,8 @@
 # Specifically for TLS settings
 http:
   routers:
-    dashboard-http:
-      rule: Host(`traefik.{{ env "LOCAL_KME_ID" }}`)
-      entryPoints: web
-      service: api@internal
     dashboard-https:
-      rule: Host(`traefik.{{ env "LOCAL_KME_ID" }}`)
+      rule: Host(`traefik.{{ env "LOCAL_KME_ADDRESS" }}`)
       entryPoints: websecure
       tls: True
       service: api@internal

--- a/volumes/kme2/traefik/configuration/traefik.d/tls.yml
+++ b/volumes/kme2/traefik/configuration/traefik.d/tls.yml
@@ -2,12 +2,8 @@
 # Specifically for TLS settings
 http:
   routers:
-    dashboard-http:
-      rule: Host(`traefik.{{ env "LOCAL_KME_ID" }}`)
-      entryPoints: web
-      service: api@internal
     dashboard-https:
-      rule: Host(`traefik.{{ env "LOCAL_KME_ID" }}`)
+      rule: Host(`traefik.{{ env "LOCAL_KME_ADDRESS" }}`)
       entryPoints: websecure
       tls: True
       service: api@internal


### PR DESCRIPTION
Currently kme1 and kme2 are hardcoded as server addresses, but endpoints may be additionally registered by the internal network DNS during deployment. The variable 'LOCAL_KME_ADDRESS' in 'Makefile' can instead be configured, which will be propagated into 'vault_init' during server certificate generation. This cuts out the need to modify the hosts file on connecting SAEs.

Wildcard domain name is used to validate all possible subdomains on KME, including traefik.

The unused 'dashboard-http' router is additionally removed.
