### PR TITLE
Rename API methods based on intent instead of request method.

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,2 @@
+# Package requirements specified for ReadTheDocs
+sphinx-tabs

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -16,7 +16,8 @@ extensions = [
     'sphinx.ext.doctest',
     'sphinx.ext.autodoc',
     'sphinx.ext.autosummary',
-    'sphinx.ext.intersphinx'
+    'sphinx.ext.intersphinx',
+    'sphinx_tabs.tabs', # https://sphinx-tabs.readthedocs.io/en/latest/
     ]
 
 #autoapi_dirs = ['../rest/app/api/api_v1/endpoints']
@@ -37,3 +38,7 @@ html_theme = 'sphinx_rtd_theme'
 
 # -- Options for EPUB output
 epub_show_urls = 'footnote'
+
+# sphinx-tabs configuration
+sphinx_tabs_disable_tab_closing = True
+# sphinx_tabs_disable_css_loading = True

--- a/docs/source/user/U_API.rst
+++ b/docs/source/user/U_API.rst
@@ -264,7 +264,7 @@ Request body example:
      ]
    }
 
-The response body is again the same as that for `Retrieve new keys`, `Retrieve new keys with extensions`_ and `Retrieve key from key ID`_.
+The response body is again the same as that for `Retrieve new keys`_, `Retrieve new keys with extensions`_ and `Retrieve key from key ID`_.
 
 ----
 

--- a/docs/source/user/U_API.rst
+++ b/docs/source/user/U_API.rst
@@ -3,230 +3,236 @@
 Application Programming Interface
 =================================
 
-The APIs that are available to the client (SAEs) 
+The API endpoints that are available to the client (SAEs) is summarized in the table below:
 
-   +------------------------+----------------------------+
-   | Method name            |   defined path             |
-   +------------------------+----------------------------+
-   | Check Vconn            | /api/v1/check_vconn/       |
-   +------------------------+----------------------------+
-   | Get status             | /api/v1/keys/sae_id/status |
-   +------------------------+----------------------------+
-   | Get key                |/api/v1/keys/sae_id/enc_keys|
-   +------------------------+----------------------------+
-   | Post key               |/api/v1/keys/sae_id/enc_keys|
-   +------------------------+----------------------------+
-   | Get Key With Key Ids   |/api/v1/keys/sae_id/dec_keys|
-   +------------------------+----------------------------+
-   | Post Key With Key Ids  |/api/v1/keys/sae_id/dec_keys|
-   +------------------------+----------------------------+
-   
+=======================================  ================
+Actions                                  Endpoint
+=======================================  ================
+`Check vault connection`_                /check_vconn
+`Get SAE status`_                        /keys/sae_id/status
+`Retrieve new keys`_                     /keys/sae_id/enc_keys
+`Retrieve new keys with extensions`_     /keys/sae_id/enc_keys
+`Retrieve key from key ID`_              /keys/sae_id/dec_keys
+`Retrieve multiple keys from key IDs`_   /keys/sae_id/dec_keys
+=======================================  ================
 
-Check Vconn
-^^^^^^^^^^^
+In the examples below, we denote the KME domain ``https://kme1/`` and current sae ``sae1``.
 
-Check Vconn is an endpoint that returns to the client the 
-connection status to the Vault running on the KME. 
+----
+
+Check vault connection
+----------------------
+
+Checks the connection status of the SAE to the Vault running on the KME.  
 No parameters are sent.
 
-The response body is
++--------------+------------------------------------------+
+| **Method:**  | GET                                      |
++--------------+------------------------------------------+
+| **Format:**  | ``/check_vconn``                         |
++--------------+------------------------------------------+
+| **Example:** | ``https://kme1/api/v1/check_vconn``      |
++--------------+------------------------------------------+
 
-.. code:: json
+.. tabs::
+
+   .. group-tab:: Response schema
+
+      .. code:: json
+        
+        {
+            "is_initialized": "bool",
+            "is_sealed": "bool",
+            "is_authenticated": "bool"
+        }
+    
+   .. group-tab:: Example successful response
+
+      .. code:: json
+        
+        {
+            "is_initialized": true,
+            "is_sealed": false,
+            "is_authenticated": true
+        }
+
+----
+
+Get SAE status
+--------------
+
+Verifies if a connection to another SAE exists. If so, return the keying material size limits and counts.  
+The parameters are sent via a GET access method with ``slave_SAE_ID`` encoded in the access URL.
+
++--------------+------------------------------------------+
+| **Method:**  | GET                                      |
++--------------+------------------------------------------+
+| **Format:**  | ``/keys/{slave_SAE_ID}/status``          |
++--------------+------------------------------------------+
+| **Example:** | ``https://kme1/api/v1/keys/sae3/status`` |
++--------------+------------------------------------------+
    
-   {
-      "is_initialized": "bool",
-      "is_sealed": "bool",
-      "is_authenticated": "bool"
-   }
-   
+.. tabs::
 
-Example Value
-   
+   .. group-tab:: Response schema
 
-.. code:: json
-   
-   {
-      "is_initialized": "true",
-      "is_sealed": "false",
-      "is_authenticated": "true"
-   }
-   
-   
-Get Status
-^^^^^^^^^^
+      .. code:: json
 
-Get status is the endpoint where the client can verify if the connection to another SAE exists and also keying materials size limits and counts.
+        {
+          "source_KME_ID": "kme1",
+          "target_KME_ID": "kme2",
+          "master_SAE_ID": "string",
+          "slave_SAE_ID": "string",
+          "key_size": "integer",
+          "stored_key_count": "integer",
+          "max_key_count": "integer",
+          "max_key_per_request": "integer",
+          "max_key_size": "integer",
+          "min_key_size": "integer",
+          "max_SAE_ID_count": "integer",
+          "status_extension": {
+            "status_extension": "string"
+          }
+        }
+    
+   .. group-tab:: Example successful response
 
-The parameters are sent via a GET access method with  ``KME_hostname`` and ``slave_SAE_ID`` encoded in the access URL.
+      .. code:: json
 
-Example request URL
-   ``https://kme1/api/v1/keys/sae3/status``
-   
+        {
+          "source_KME_ID": "kme1",
+          "target_KME_ID": "kme2",
+          "master_SAE_ID": "sae1",
+          "slave_SAE_ID": "sae3",
+          "key_size": 32,
+          "stored_key_count": 1150,
+          "max_key_count": 1048576,
+          "max_key_per_request": 100,
+          "max_key_size": 65536,
+          "min_key_size": 8,
+          "max_SAE_ID_count": 0
+        }
 
-The Response body is
+----
 
-.. code:: json
+Retrieve new keys
+-----------------
 
-   {
-     "source_KME_ID": "kme1",
-     "target_KME_ID": "kme2",
-     "master_SAE_ID": "string",
-     "slave_SAE_ID": "string",
-     "key_size": "integer",
-     "stored_key_count": "integer",
-     "max_key_count": "integer",
-     "max_key_per_request": "integer",
-     "max_key_size": "integer",
-     "min_key_size": "integer",
-     "max_SAE_ID_count": "integer",
-     "status_extension": {
-       "status_extension": "string"
-     }
-   }
-   
-Example Value for success
-
-.. code:: json
-
-   }
-     "source_KME_ID": "kme1",
-     "target_KME_ID": "kme2",
-     "master_SAE_ID": "sae1",
-     "slave_SAE_ID": "sae4",
-     "key_size": 32,
-     "stored_key_count": 1150,
-     "max_key_count": 1048576,
-     "max_key_per_request": 100,
-     "max_key_size": 65536,
-     "min_key_size": 8,
-     "max_SAE_ID_count": 0
-   }
-   
-.. For Failure   
-   
-Get key
-^^^^^^^
-
-Get key is called by the master SAE with the slave SAE_id and optional number of keys and size. The source KME will negotiate with the target KME where the slave SAE resides to generate symmetric keys encoded in `**base64**`__ for the master and slave SAEs 
-
-.. __: https://www.rfc-editor.org/info/rfc4648
+Called by the master SAE with the slave ``SAE_id`` and optional number of keys and size. The source KME will negotiate with the target KME where the slave SAE resides to generate symmetric keys encoded in `base64 <https://www.rfc-editor.org/info/rfc4648>`_ for the master and slave SAEs.
 
 Parameters are sent via a GET access method with ``KME_hostname`` and ``slave_SAE_ID`` encoded in the access URL. Optional parameters ``numbers`` and ``size`` will default to 1 and 32 (bits) if unspecified.
 
-Example request URL
-   ``https://kme1/api/v1/keys/sae2/enc_keys?number=2&size=24``
++--------------+-------------------------------------------------------------+
+| **Method:**  | GET                                                         |
++--------------+-------------------------------------------------------------+
+| **Format:**  | ``/keys/{slave_SAE_ID}/enc_keys``                           |
++--------------+-------------------------------------------------------------+
+| **Example:** | ``https://kme1/api/v1/keys/sae2/enc_keys?number=2&size=24`` |
++--------------+-------------------------------------------------------------+
 
-The response body is
+.. tabs::
 
-.. code:: json
-   
-   {
-     "key_container_extension": "string",
-     "keys": [
-       {
-         "key_extension": "string",
-         "key": "string",
-         "key_ID_extension": "string",
-         "key_ID": "string"
-       }
-     ]
-   }   
-   
-with options ``key_container_extension``, ``key_extension`` and ``key_ID_extension`` defined for future use.
-   
-Example Value for success
+   .. group-tab:: Response schema
 
-.. code:: json
+      .. code:: json
+        
+        {
+          "key_container_extension": "string",
+          "keys": [
+            {
+              "key_extension": "string",
+              "key": "string",
+              "key_ID_extension": "string",
+              "key_ID": "string"
+            }
+          ]
+        }
+      
+      with options ``key_container_extension``, ``key_extension`` and ``key_ID_extension`` defined for future use.
+    
+   .. group-tab:: Example successful response
 
-   {
-     "keys": [
-       {
-         "key": "2Azd",
-         "key_ID": "a6c4048f-a9ff-5661-b281-9d4ab9893dff"
-       },
-       {
-         "key": "BUl7",
-         "key_ID": "296a7e8e-fcde-5539-aaee-92e629d169d0"
-       }
-     ]
-   }
+      .. code:: json
 
+        {
+          "keys": [
+            {
+              "key": "2Azd",
+              "key_ID": "a6c4048f-a9ff-5661-b281-9d4ab9893dff"
+            },
+            {
+              "key": "BUl7",
+              "key_ID": "296a7e8e-fcde-5539-aaee-92e629d169d0"
+            }
+          ]
+        }
 
-Post key
-^^^^^^^^
+----
 
-Similar to Get Key, but with a Post access method instead. With this method, the SAE may specify additional options of ``additional_slave_SAE_IDs``, ``extension_mandatory`` and ``extension_optional`` in the request. These however are not implement by Guardian.
+Retrieve new keys with extensions
+---------------------------------
 
-Example request URL
-   ``https://kme1/api/v1/keys/sae2/enc_keys``
-   
-The request body is 
+Similar to `Retrieve new keys`_, but with a POST access method instead. With this method, the SAE may specify additional options of ``additional_slave_SAE_IDs``, ``extension_mandatory`` and ``extension_optional`` in the request. These are currently not implemented by Guardian.
 
-.. code:: json
++--------------+-------------------------------------------------------------+
+| **Method:**  | POST                                                        |
++--------------+-------------------------------------------------------------+
+| **Format:**  | ``/keys/{slave_SAE_ID}/enc_keys``                           |
++--------------+-------------------------------------------------------------+
+| **Example:** | ``https://kme1/api/v1/keys/sae2/enc_keys``                  |
++--------------+-------------------------------------------------------------+
 
-   {
-     "number": 1,
-     "size": 32,
-     "additional_slave_SAE_IDs": [],
-     "extension_mandatory": [
-       {}
-     ],
-     "extension_optional": [
-       {}
-     ]
-   }
-
-The response body is the same as Get Key
+Request body:
 
 .. code:: json
+
+  {
+    "number": 1,
+    "size": 32,
+    "additional_slave_SAE_IDs": [],
+    "extension_mandatory": [
+      {}
+    ],
+    "extension_optional": [
+      {}
+    ]
+  }
+
+The response body is the same as `Retrieve new keys`_.
+
+----
+
+Retrieve key from key ID
+------------------------
+
+Retrives the matching key from the KME through the use of the Key ID(s) that the master SAE notified the Slave SAE. This method is called by the Slave SAE on his/her target KME.
+
++--------------+----------------------------------------------------------------------------------------+
+| **Method:**  | GET                                                                                    |
++--------------+----------------------------------------------------------------------------------------+
+| **Format:**  | ``/keys/{master_SAE_ID}/dec_keys``                                                     |
++--------------+----------------------------------------------------------------------------------------+
+| **Example:** | ``https://kme1/api/v1/keys/sae1/dec_keys?key_ID=ce9d2863-d4f8-522d-aa5a-95fcd1320648`` |
++--------------+----------------------------------------------------------------------------------------+
+
+The response body is the also the same as that of `Retrieve new keys`_ and `Retrieve new keys with extensions`_.
+
+----
+
+Retrieve multiple keys from key IDs
+-----------------------------------
+
+Retrieves one or more keys from the KME by specifying one or more key IDs.
+
++--------------+--------------------------------------------+
+| **Method:**  | POST                                       |
++--------------+--------------------------------------------+
+| **Format:**  | ``/keys/{master_SAE_ID}/dec_keys``         |
++--------------+--------------------------------------------+
+| **Example:** | ``https://kme1/api/v1/keys/sae1/dec_keys`` |
++--------------+--------------------------------------------+
    
-   {
-     "key_container_extension": "string",
-     "keys": [
-       {
-         "key_extension": "string",
-         "key": "string",
-         "key_ID_extension": "string",
-         "key_ID": "string"
-       }
-     ]
-   }   
-   
-   
-Get Key With Key Ids
-^^^^^^^^^^^^^^^^^^^^
-
-This method is called by the Slave SAE on his/her target KME. It retrives the matching key from the KME through the use of the Key Id(s) that the master SAE notified the Slave SAE.
-
-Example request URL
-   ``https://kme2/api/v1/keys/sae1/dec_keys?key_ID=ce9d2863-d4f8-522d-aa5a-95fcd1320648``
-
-The response body is the also the same as Get Key and Post Key
-
-.. code:: json
-   
-   {
-     "key_container_extension": "string",
-     "keys": [
-       {
-         "key_extension": "string",
-         "key": "string",
-         "key_ID_extension": "string",
-         "key_ID": "string"
-       }
-     ]
-   }   
-   
-
-Post Key With Key Ids
-^^^^^^^^^^^^^^^^^^^^^
-
-If more than one Key needs to be retrived from multiple Key Ids, then the Post method is used.
-
-Example request URL
-   ``https://kme2/api/v1/keys/sae1/dec_keys``
-   
-The request body is the same as 
+Request body:
 
 .. code:: json
 
@@ -240,7 +246,7 @@ The request body is the same as
      ]
    }
 
-Example request body,
+Request body example:
 
 .. code:: json
 
@@ -258,21 +264,21 @@ Example request body,
      ]
    }
 
-The Response body is again the same as that for Get Key, Post key and Get key with Key Id
+The response body is again the same as that for `Retrieve new keys`, `Retrieve new keys with extensions`_ and `Retrieve key from key ID`_.
 
+----
 
 HTTP Error Codes
 ----------------
 
-All APIs except for Check Vconn may return the following responses.
+All endpoints except for `Check vault connection`_ may return the following responses.
 
 ==================   ======================  ======================
 HTTP status code     Response data model     Description
 ==================   ======================  ======================
-200                  Success                 Successful Response.
-400                  Error                   Bad request format.
-401                  -                       Unauthorized.
-422                  Error                   Validation Error.
-503                  Error                   Error on Server side.
+200                  Success                 Successful Response
+400                  Error                   Bad request format
+401                  `-`                     Unauthorized
+422                  Error                   Validation Error
+503                  Error                   Error on Server side
 ==================   ======================  ======================
-

--- a/docs/source/user/U_API.rst
+++ b/docs/source/user/U_API.rst
@@ -231,38 +231,40 @@ Retrieves one or more keys from the KME by specifying one or more key IDs.
 +--------------+--------------------------------------------+
 | **Example:** | ``https://kme1/api/v1/keys/sae1/dec_keys`` |
 +--------------+--------------------------------------------+
-   
-Request body:
 
-.. code:: json
+.. tabs::
 
-   {
-     "key_IDs_extension": "string",
-     "key_IDs": [
-       {
-         "key_ID_extension": "string",
-         "key_ID": "string"
-       }
-     ]
-   }
+   .. group-tab:: Request schema
 
-Request body example:
+      .. code:: json
 
-.. code:: json
+         {
+           "key_IDs_extension": "string",
+           "key_IDs": [
+             {
+               "key_ID_extension": "string",
+               "key_ID": "string"
+             }
+           ]
+         }
 
-   {
-     "key_IDs_extension": "string",
-     "key_IDs": [
-       {
-         "key_ID_extension": "",
-         "key_ID": "f1f13be6-fc07-58d8-bd44-aabad86a4dc1"
-       },
-       {
-         "key_ID_extension": "",
-         "key_ID": "0e21abe7-1679-5832-82a6-fd27cff4a653"
-       }
-     ]
-   }
+   .. group-tab:: Request body Example
+
+      .. code:: json
+
+         {
+           "key_IDs_extension": "string",
+           "key_IDs": [
+             {
+               "key_ID_extension": "",
+               "key_ID": "f1f13be6-fc07-58d8-bd44-aabad86a4dc1"
+             },
+             {
+               "key_ID_extension": "",
+               "key_ID": "0e21abe7-1679-5832-82a6-fd27cff4a653"
+             }
+           ]
+         }
 
 The response body is again the same as that for `Retrieve new keys`_, `Retrieve new keys with extensions`_ and `Retrieve key from key ID`_.
 

--- a/docs/source/user/usage.rst
+++ b/docs/source/user/usage.rst
@@ -1,24 +1,19 @@
 Usage
 =====
 
-Once the :ref:`requirements <prerequisites>` are in place, any modern web client, programming packages with TLS support, etc. can be used to access the APIs. We list examples using Chrome based Web browser, and python Request library.
-
-We assume that the SAE key-certificate pair together with the root CA is already installed in the certificate manager used by the Web browser for the first example. 
-In the other examples, the key-certificate pair is in a PEM format in the same directory as that the commands are executed in.
-Also, the hostname kme1 and kme2 directs to the correct KMEs with sae1 and sae2 the clients that can authenticate respectively.
-
+Once the :ref:`requirements <prerequisites>` are in place, any modern web client, programming packages with TLS support, etc. can be used to access the APIs. We list examples using Microsoft Edge (Chromium-based) web browser, and Python's ``request`` library, with hostnames ``kme1`` and ``kme2`` indicating the corresponding KMEs that ``sae1`` and ``sae2`` can authenticate respectively.
 
 Web Browser
 -----------
+
+In this web browser example, the SAE key-certificate pair together with the root CA is already installed in the certificate manager used by the web browser for the first example. 
 
 We type the URL, ``https://kme1/api/v1/keys/sae2/status`` to get the status of the connection between KME1 to the KME that handles SAE2 which is KME2 in this example. Before the connection continues, the correct certificate needs to be presented to the server for authentication.
 
 .. figure:: ./images/chrome_choose_cert.png
    :alt: Choose certificate
    
-   Chrome prompts which certificate to use to do mutual authentication.
-   
-   
+   The web browser prompts which certificate to use to do mutual authentication.
    
 .. figure:: ./images/chrome_status.png
    :alt: Status of connection to SAE2
@@ -44,7 +39,7 @@ Now sae1 has 3 keys with their corresponding key_IDs. The key_IDs are communicat
 .. figure:: ./images/chrome_choose_cert_kme2.png
    :alt: Choose certificate to communicate to kme2
    
-   Chrome prompts which certificate to use to do mutual authentication for sae2 and kme2.
+   The web browser prompts which certificate to use to do mutual authentication for sae2 and kme2.
    
 Now we identify as sae2 itself sae2 certificate to kme2. With the Get method we send the URL ``https://kme2/api/v1/keys/sae1/dec_keys?key_ID=3f58ec7a-499b-5a05-b475-dd5f1e78092b``. With the Get method we can only request one key at a time.
 
@@ -65,50 +60,50 @@ Once the key is retrived, it is deleted from KME2 and a subsequent call is made,
    
    sae2 tries to retrives the same key again from KME2. ``https://kme2/api/v1/keys/sae1/dec_keys?key_ID=4d90c421-a5fa-55c8-8da6-3e6ebde75477``   
 
-With this, sae1 and sae2 a set of QKD keys that they can use to communicate with each other.
-
+With this, ``sae1`` and ``sae2`` both share a set of QKD keys that they can use to communicate with each other.
 
 .. |default_size| replace:: 32
-
 
 
 Python
 ------
 
-In python, the ``requests`` module can be used to emulate the web browser functionality. Also there are several ways to do SSL verification. In this Windows example, we load the root CA certificate to the Microsoft certificate store as a trusted CA and use ``python-certifi-win32``
+In this Python 3 example, the key-certificate pair is in a PEM format in the same directory as that the commands are executed in. Some packages to install first:
 
 .. code-block:: dosbatch
    
    pip install requests python-certifi-win32
 
-If installed correctly, then the rest API can be accessed via
+In python, the ``requests`` module can be used to dispatch GET/POST calls without a web browser GUI. There are also several ways to do client-side verification of server: here we load the KME's root CA certificate into the Microsoft certificate store as a trusted CA on Windows, and loads this store into Python using ``python-certifi-win32``.
+
+An example script to interface with the API:
 
 .. code-block:: python
-   :caption: Script
    :linenos:
    
    import requests
-   
-   cert_path='/path/to/cert'
-   key_path='/path/to/key'
-   status_url='https://kme1/api/v1/keys/sae2/status'
+   cert_path = '/path/to/cert'
+   key_path = '/path/to/key'
+
+   status_url = 'https://kme1/api/v1/keys/sae2/status'
    print('Checking connection to kme1...')
-   response = requests.get(status_url,cert=(cert_path,key_path))
+   response = requests.get(status_url, cert=(cert_path,key_path))
    print('Connection to kme1 OK.')
    print(response.content)
 
-   get_key_url='https://kme1/api/v1/keys/sae2/enc_keys'
-   response = requests.get(get_key_url,cert=(cert_path,key_path))
+   get_key_url = 'https://kme1/api/v1/keys/sae2/enc_keys'
+   response = requests.get(get_key_url, cert=(cert_path,key_path))
    print(response.content)
-
 
 Similarly, for a POST request,
 
 .. code-block:: python
-   
-   get_key_url='https://kme1/api/v1/keys/sae2/enc_keys'
-   query={'number': 1 , 'size': 32}
-   response = requests.post(get_key_url,cert=(cert_path,key_path),json=query)
+   :linenos:
+   :lineno-start: 14
+
+   get_key_url = 'https://kme1/api/v1/keys/sae2/enc_keys'
+   query = {'number': 1, 'size': 32}
+   response = requests.post(get_key_url, cert=(cert_path,key_path), data=query)
    print(response.json())
 
 


### PR DESCRIPTION
Added original variables into endpoint to reflect the actual query, e.g. 'slave_SAE_ID'. Grouped response schemas and example for quick comparison.

Adds new dependency on 'sphinx-tabs'.

![image](https://user-images.githubusercontent.com/28663438/147227167-1ae33222-9fbf-42a7-9b35-9e33b00b199a.png)
